### PR TITLE
Enabled option for forcing cookies to be sent only over https

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -287,7 +287,7 @@ module.exports = function auth( options ) {
         args.req$.seneca.user = user
         args.req$.seneca.login = login
 
-        args.res$.seneca.cookies.set(options.tokenkey,login.id)
+        args.res$.seneca.cookies.set(options.tokenkey,login.id,options)
 
         done(null,{ok:true,user:user,login:login})
       }
@@ -396,7 +396,7 @@ module.exports = function auth( options ) {
           req.seneca.login = out.login
 
           if( res && res.seneca ) {
-            res.seneca.cookies.set(options.tokenkey,req.seneca.login.id)
+            res.seneca.cookies.set(options.tokenkey,req.seneca.login.id,options)
           }
         }
 
@@ -675,11 +675,11 @@ module.exports = function auth( options ) {
         var context = req.query && req.query.context
 
         if( void 0 != prefix && '' != prefix ) {
-          res.seneca.cookies.set(options.transientprefix+'url-prefix',prefix)
+          res.seneca.cookies.set(options.transientprefix+'url-prefix',prefix,options)
         }
 
         if( void 0 != context && '' != context ) {
-          res.seneca.cookies.set(options.transientprefix+'context',context)
+          res.seneca.cookies.set(options.transientprefix+'context',context,options)
         }
 
         if (service != 'local') {
@@ -812,7 +812,7 @@ module.exports = function auth( options ) {
 
         adminlocal(req,req.seneca.user)
 
-        res.seneca.cookies.set(options.tokenkey,req.seneca.login.id)
+        res.seneca.cookies.set(options.tokenkey,req.seneca.login.id,options)
 
         if( '' != context ) {
           req.seneca.login.context = context

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -2,16 +2,18 @@
 
 var assert = require('assert')
 var seneca = require('seneca')
+var Cookies = require('cookies')
 
 var si = seneca()
 si.use( 'user' )
-si.use( require('..') )
+si.use( require('..'),{secure:true} )
 
 var useract = si.pin({role:'user',cmd:'*'})
 var authact = si.pin({role:'auth',cmd:'*'})
 
 
 describe('auth', function() {
+
   it('happy', function(cb) {
 
     authact.register({data:{nick:'u1',name:'u1n',password:'u1p'}},function(err,out){
@@ -21,6 +23,26 @@ describe('auth', function() {
       assert.ok(out.user)
       assert.ok(out.login)
       cb()
+    })
+
+  })
+
+  it('use secure option', function(cb) {
+
+    var res = {}
+    var req = {}
+
+    si.cookies = { set: function(tokenkey,id,options){
+      assert.ok(options.secure)
+
+      cb()
+    }}
+    res.seneca = si
+    req.seneca = si
+    authact.login({user:{nick:'u1',name:'u1n',password:'u1p'},auto:true,req$:req,res$:res},function(err,out){
+      if( err ) return cb(err);
+
+
     })
 
   })


### PR DESCRIPTION
i passed options to cookies library so that we can enable the secure option in the library. This allow to check that cookies are sent only over https connections.

Added also related test.